### PR TITLE
Add Lindhard susceptibility calculation capability

### DIFF
--- a/doc/source/input.rst
+++ b/doc/source/input.rst
@@ -341,6 +341,9 @@ We listed those features in the table below.
 | JDos_calc            | Joint Density of state   |  jdos.dat                       |      yes        |
 |                      | for 3D bulk system       |                                 |                 |
 +----------------------+--------------------------+---------------------------------+-----------------+
+| Lindhard_calc        | Lindhard susceptibility  |  lindhard.dat                   |      no         |
+|                      | chi(q, omega) grids      |                                 |                 |
++----------------------+--------------------------+---------------------------------+-----------------+
 | SlabSS_calc          | Surface spectrum A(k,E)  | dos.dat_l, dos.dat_r,           |      yes        |
 |                      | along a kline and energy | dos.dat_bulk,surfdos_l.gnu,     |                 |
 |                      | interval for slab system | surfdos_r.gnu,                  |                 |
@@ -433,9 +436,23 @@ In this namelists, we listed some parameters necessary in the task you specified
 
 **OmegaNum** : integer valued, Number of slices in the energy interval [OmegaMin, OmegaMax]. used if SlabSS_calc= T. The default value is 100.
 
+**Lindhard_omega_min, Lindhard_omega_max** : real-valued, frequency window for the Lindhard susceptibility evaluation when ``Lindhard_calc = T``. They inherit the values of ``OmegaMin`` and ``OmegaMax`` if not provided explicitly.
+
+**Lindhard_omega_num** : integer valued, number of frequency samples for the Lindhard calculation. Defaults to ``OmegaNum`` and should be no smaller than 2.
+
+**Lindhard_broadening** : real-valued, phenomenological broadening (imaginary part of the frequency) used when accumulating ``chi(q,\omega)``. The default equals ``Fermi_broadening``.
+
 **Nk1, Nk2, Nk3** : integer valued, Number of k points for different purpose. I will explain that later. Default value is Nk1=20, Nk2=20, Nk3=20.
 
-**NP** : integer valued, Number of principle layers, see details related to iterative green’s function. Used if  SlabSS_calc= T, SlabArc_calc=T, SlabSpintexture_calc=T. Default value is 2. You need to do a convergence test by setting Np= 1, Np=2, Np=3, and check the surface state spectrum. Basically, the value of Np depends on the spread of Wannier functions you constructed. One thing should be mentioned is that the computational time grows cubically of Np. 
+**Lindhard_Nk1, Lindhard_Nk2, Lindhard_Nk3** : integer valued, sizes of the Brillouin-zone k mesh used in the Lindhard routine. By default they follow ``Nk1``, ``Nk2`` and ``Nk3``.
+
+**Lindhard_Nq1, Lindhard_Nq2, Lindhard_Nq3** : integer valued, q-grid dimensions for the susceptibility. They default to the corresponding Lindhard k-mesh sizes.
+
+**Lindhard_q_start** : real-valued vector, fractional starting point of the q-grid. The default is the origin of the Brillouin zone.
+
+**Lindhard_output** : character string, filename for the susceptibility table written by the Lindhard calculation. The default is ``lindhard.dat``.
+
+**NP** : integer valued, Number of principle layers, see details related to iterative green’s function. Used if  SlabSS_calc= T, SlabArc_calc=T, SlabSpintexture_calc=T. Default value is 2. You need to do a convergence test by setting Np= 1, Np=2, Np=3, and check the surface state spectrum. Basically, the value of Np depends on the spread of Wannier functions you constructed. One thing should be mentioned is that the computational time grows cubically of Np.
 
 **Gap_threshold** :  real valued. This value is used when you do energy gap calculation like BulkGap_cube_calc=T, BulkGap_plane_calc=T. The k points will be printed out in a file when the energy gap is smaller than Gap_threshold. 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,8 +10,9 @@ OBJ =  module.o sparse.o wt_aux.o math_lib.o symmetry.o \
 		 berry.o wanniercenter_adaptive.o \
   		 effective_mass.o findnodes.o \
 		 sigma_OHE.o sigma.o Boltz_transport_anomalous.o \
-		 2D_TSC.o optic.o orbital_hall.o\
-		main.o
+                 2D_TSC.o optic.o orbital_hall.o\
+                 lindhard.o \
+                 main.o
 
 # compiler
 #F90  = mpif90 -fpp -DMPI -fpe3 -O3 -DARPACK -DINTELMKL #-check all -traceback -g

--- a/src/lindhard.f90
+++ b/src/lindhard.f90
@@ -1,0 +1,205 @@
+module lindhard_module
+   use sparse
+   use wmpi
+   use para
+   implicit none
+contains
+
+   subroutine compute_lindhard()
+      implicit none
+
+      integer :: nq1, nq2, nq3, nk1, nk2, nk3
+      integer :: nq_total, nk_total
+      integer :: iq, ik, iqx, iqy, iqz, ikx, iky, ikz
+      integer :: neval, nvecs, ndimq, nnz, nnzmax, ierr
+      integer :: iomega, ib, jb
+      real(dp) :: dk_weight
+      real(dp) :: Beta_fake
+      real(dp) :: broad
+      real(dp) :: k(3), q(3), kq(3)
+      real(dp) :: occ_k, occ_kq
+      real(dp) :: freq
+      real(dp), allocatable :: omega(:)
+      real(dp), allocatable :: eig_k(:), eig_kq(:)
+      real(dp), allocatable :: work_eigs(:)
+      complex(dp), allocatable :: chi_local(:, :)
+      complex(dp), allocatable :: chi_total(:, :)
+      complex(dp), allocatable :: acoo_k(:), acoo_q(:)
+      integer, allocatable :: icoo_k(:), jcoo_k(:)
+      integer, allocatable :: icoo_q(:), jcoo_q(:)
+      complex(dp), allocatable :: zeigv(:, :)
+      complex(dp) :: denom
+      logical :: ritzvec
+      real(dp), external :: fermi
+
+      nq1 = Lindhard_Nq1
+      nq2 = Lindhard_Nq2
+      nq3 = Lindhard_Nq3
+      nk1 = Lindhard_Nk1
+      nk2 = Lindhard_Nk2
+      nk3 = Lindhard_Nk3
+
+      nq_total = nq1*nq2*nq3
+      nk_total = nk1*nk2*nk3
+
+      if (nq_total <= 0 .or. nk_total <= 0) then
+         if (cpuid == 0) then
+            write(stdout, '(a)') '>> Lindhard calculation skipped because the k/q mesh is empty.'
+         end if
+         return
+      end if
+
+      ndimq = Num_wann
+      neval = NumSelectedEigenVals
+      if (neval <= 0) neval = ndimq
+      if (ndimq > 2) then
+         if (neval > ndimq - 2) neval = ndimq - 2
+      else
+         neval = ndimq
+      end if
+      if (neval < 1) neval = ndimq
+
+      nvecs = int(1.5_dp*neval)
+      if (nvecs < 50) nvecs = 50
+      if (nvecs > ndimq) nvecs = ndimq
+
+      nnz = splen
+      nnzmax = splen + ndimq
+
+      allocate(omega(Lindhard_omega_num))
+      if (Lindhard_omega_num <= 1) then
+         omega(1) = Lindhard_omega_min
+      else
+         do iomega = 1, Lindhard_omega_num
+            omega(iomega) = Lindhard_omega_min + (Lindhard_omega_max - Lindhard_omega_min) * &
+               (dble(iomega - 1) / dble(Lindhard_omega_num - 1))
+         end do
+      end if
+
+      allocate(eig_k(neval))
+      allocate(eig_kq(neval))
+      allocate(work_eigs(ndimq))
+      allocate(zeigv(ndimq, nvecs))
+      allocate(acoo_k(nnzmax))
+      allocate(icoo_k(nnzmax))
+      allocate(jcoo_k(nnzmax))
+      allocate(acoo_q(nnzmax))
+      allocate(icoo_q(nnzmax))
+      allocate(jcoo_q(nnzmax))
+      allocate(chi_local(Lindhard_omega_num, nq_total))
+      allocate(chi_total(Lindhard_omega_num, nq_total))
+
+      chi_local = (0.0_dp, 0.0_dp)
+      chi_total = (0.0_dp, 0.0_dp)
+
+      dk_weight = 1.0_dp / dble(nk_total)
+      Beta_fake = Beta
+      if (Beta_fake <= 0.0_dp) Beta_fake = 1.0d12
+      broad = Lindhard_broadening
+
+      ritzvec = .false.
+
+      do iq = 1 + cpuid, nq_total, num_cpu
+         iqx = (iq - 1) / (nq2*nq3) + 1
+         iqy = ((iq - 1 - (iqx - 1)*nq2*nq3) / nq3) + 1
+         iqz = iq - (iqy - 1)*nq3 - (iqx - 1)*nq2*nq3
+
+         q = Lindhard_q_start + K3D_vec1_cube * dble(iqx - 1) / dble(max(1, nq1)) &
+            + K3D_vec2_cube * dble(iqy - 1) / dble(max(1, nq2)) &
+            + K3D_vec3_cube * dble(iqz - 1) / dble(max(1, nq3))
+
+         do ik = 1, nk_total
+            ikx = (ik - 1) / (nk2*nk3) + 1
+            iky = ((ik - 1 - (ikx - 1)*nk2*nk3) / nk3) + 1
+            ikz = ik - (iky - 1)*nk3 - (ikx - 1)*nk2*nk3
+
+            k = K3D_start_cube + K3D_vec1_cube * dble(ikx - 1) / dble(max(1, nk1)) &
+               + K3D_vec2_cube * dble(iky - 1) / dble(max(1, nk2)) &
+               + K3D_vec3_cube * dble(ikz - 1) / dble(max(1, nk3))
+
+            kq = k + q
+            kq(1) = modulo(kq(1), 1.0_dp)
+            kq(2) = modulo(kq(2), 1.0_dp)
+            kq(3) = modulo(kq(3), 1.0_dp)
+
+            call ham_bulk_coo_sparsehr(k, acoo_k, icoo_k, jcoo_k)
+            call arpack_sparse_coo_eigs(ndimq, nnzmax, nnz, acoo_k, jcoo_k, icoo_k, neval, nvecs, &
+               work_eigs, (0.0_dp, 0.0_dp), zeigv, ritzvec)
+            eig_k(:) = work_eigs(1:neval)
+
+            call ham_bulk_coo_sparsehr(kq, acoo_q, icoo_q, jcoo_q)
+            call arpack_sparse_coo_eigs(ndimq, nnzmax, nnz, acoo_q, jcoo_q, icoo_q, neval, nvecs, &
+               work_eigs, (0.0_dp, 0.0_dp), zeigv, ritzvec)
+            eig_kq(:) = work_eigs(1:neval)
+
+            do ib = 1, neval
+               occ_k = fermi(eig_k(ib) - iso_energy, Beta_fake)
+               do jb = 1, neval
+                  occ_kq = fermi(eig_kq(jb) - iso_energy, Beta_fake)
+                  if (abs(occ_k - occ_kq) < 1.0d-12) cycle
+                  do iomega = 1, Lindhard_omega_num
+                     freq = omega(iomega)
+                     denom = (freq + zi*broad) + (eig_k(ib) - eig_kq(jb))
+                     chi_local(iomega, iq) = chi_local(iomega, iq) + (occ_k - occ_kq) / denom
+                  end do
+               end do
+            end do
+         end do
+
+         chi_local(:, iq) = chi_local(:, iq) * dk_weight
+      end do
+
+#if defined (MPI)
+      call mpi_allreduce(chi_local, chi_total, size(chi_local), mpi_dc, mpi_sum, mpi_cmw, ierr)
+#else
+      chi_total = chi_local
+#endif
+
+      if (cpuid == 0) then
+         character(len=*), parameter :: fmt_header = '(a, 3f16.6)'
+         character(len=*), parameter :: fmt_line = '(f16.8, 2f20.10)'
+         real(dp) :: q_cart(3)
+         integer :: unit_id
+
+         unit_id = outfileindex + 1
+         outfileindex = outfileindex + 1
+         open(unit=unit_id, file=trim(Lindhard_output))
+         write(unit_id, '(a)') '# Lindhard susceptibility chi(q, omega)'
+         write(unit_id, '(a)') '# omega in eV, chi in 1/eV'
+         do iq = 1, nq_total
+            iqx = (iq - 1) / (nq2*nq3) + 1
+            iqy = ((iq - 1 - (iqx - 1)*nq2*nq3) / nq3) + 1
+            iqz = iq - (iqy - 1)*nq3 - (iqx - 1)*nq2*nq3
+
+            q = Lindhard_q_start + K3D_vec1_cube * dble(iqx - 1) / dble(max(1, nq1)) &
+               + K3D_vec2_cube * dble(iqy - 1) / dble(max(1, nq2)) &
+               + K3D_vec3_cube * dble(iqz - 1) / dble(max(1, nq3))
+            write(unit_id, fmt_header) '# q (fractional) =', q
+            q_cart = q(1)*Origin_cell%Kua + q(2)*Origin_cell%Kub + q(3)*Origin_cell%Kuc
+            write(unit_id, fmt_header) '# q (cartesian 1/Angstrom) =', q_cart*Angstrom2atomic
+            do iomega = 1, Lindhard_omega_num
+               write(unit_id, fmt_line) omega(iomega)/eV2Hartree, &
+                  real(chi_total(iomega, iq))*eV2Hartree, aimag(chi_total(iomega, iq))*eV2Hartree
+            end do
+            write(unit_id, '(a)') ' '
+         end do
+         close(unit_id)
+      end if
+
+      deallocate(omega)
+      deallocate(eig_k)
+      deallocate(eig_kq)
+      deallocate(work_eigs)
+      deallocate(zeigv)
+      deallocate(acoo_k)
+      deallocate(icoo_k)
+      deallocate(jcoo_k)
+      deallocate(acoo_q)
+      deallocate(icoo_q)
+      deallocate(jcoo_q)
+      deallocate(chi_local)
+      deallocate(chi_total)
+
+   end subroutine compute_lindhard
+
+end module lindhard_module

--- a/src/main.f90
+++ b/src/main.f90
@@ -36,6 +36,7 @@
 
      use wmpi
      use para
+     use lindhard_module, only: compute_lindhard
      implicit none
 
      !> file existence
@@ -405,6 +406,16 @@
            call print_time_cost(time_start, time_end, 'JDos_calc')
            if(cpuid.eq.0)write(stdout, *)'<< End of calculating the JDOS for bulk system'
         endif
+     endif
+
+     if (Lindhard_calc) then
+        if(cpuid.eq.0)write(stdout, *)' '
+        if(cpuid.eq.0)write(stdout, *)'>> Start of computing the Lindhard susceptibility'
+        call now(time_start)
+        call compute_lindhard()
+        call now(time_end)
+        call print_time_cost(time_start, time_end, 'Lindhard_calc')
+        if(cpuid.eq.0)write(stdout, *)'<< End of computing the Lindhard susceptibility'
      endif
 
      !> effective mass

--- a/src/module.f90
+++ b/src/module.f90
@@ -365,6 +365,7 @@
      character(80) :: Particle           ! phonon, electron
      character(80) :: Package            ! VASP, QE
      character(80) :: KPorTB             ! KP or TB
+     character(256) :: Lindhard_output   ! Output filename for Lindhard susceptibility
      logical       :: Orthogonal_Basis   ! True or False for Orthogonal basis or non-orthogonal basis
      logical :: Is_Sparse_Hr, Is_Sparse, Is_Hrfile
      namelist / TB_FILE / Hrfile, Particle, Package, KPorTB, Is_Hrfile, &
@@ -393,6 +394,7 @@
      logical :: WireBand_calc  ! Flag for 1D wire energy band calculation
      logical :: SlabSS_calc    ! Flag for surface state ARPES spectrum calculation
      logical :: Dos_calc       ! Flag for density of state calculation
+     logical :: Lindhard_calc  ! Flag for Lindhard susceptibility calculation
      logical :: Dos_slab_calc       ! Flag for density of state calculation for slab system
      logical :: ChargeDensity_selected_bands_calc       ! Flag for charge density 
      logical :: ChargeDensity_selected_energies_calc       ! Flag for charge density 
@@ -494,7 +496,7 @@
                           LandauLevel_B_calc, LandauLevel_kplane_calc,landau_chern_calc, &
                           FermiLevel_calc,ANE_calc, export_newhr,export_maghr,w3d_nested_calc, &
                           valley_projection_calc, Matrix_Element_calc, BdGChern_calc, SlabBdG_calc, BdG_phase_calc, &
-                          linear_optic_calc, BPVE_calc, Intra_orbital_hall_calc
+                          linear_optic_calc, BPVE_calc, Intra_orbital_hall_calc, Lindhard_calc
 
      integer :: Nslab  ! Number of slabs for 2d Slab system
      integer :: Nslab1 ! Number of slabs for 1D wire system
@@ -523,6 +525,12 @@
      integer :: Nk1  ! number of k points for different use
      integer :: Nk2  ! number of k points for different use
      integer :: Nk3  ! number of k points for different use
+     integer :: Lindhard_Nk1  ! number of k points for Lindhard calculation
+     integer :: Lindhard_Nk2  ! number of k points for Lindhard calculation
+     integer :: Lindhard_Nk3  ! number of k points for Lindhard calculation
+     integer :: Lindhard_Nq1  ! number of q points for Lindhard calculation
+     integer :: Lindhard_Nq2  ! number of q points for Lindhard calculation
+     integer :: Lindhard_Nq3  ! number of q points for Lindhard calculation
      integer, parameter :: Nk2_max= 4096   ! maximum number of k points 
 
      integer, public, save :: Nr1=5
@@ -544,6 +552,7 @@
 
    
      integer :: OmegaNum   ! The number of energy slices between OmegaMin and OmegaMax
+     integer :: Lindhard_omega_num   ! Frequency slices for Lindhard susceptibility
      integer :: OmegaNum_unfold   ! The number of energy slices between OmegaMin and OmegaMax
      real(dp), allocatable :: Omega_array(:)
 
@@ -552,7 +561,9 @@
 
      integer :: NumRandomConfs  !> number of random configurations, used in the Lanczos DOS calculation, default is 1
 
-     real(dp) :: OmegaMin, OmegaMax ! omega interval 
+     real(dp) :: OmegaMin, OmegaMax ! omega interval
+     real(dp) :: Lindhard_omega_min, Lindhard_omega_max
+     real(dp) :: Lindhard_broadening
   
      real(Dp) :: E_arc ! Fermi energy for arc calculation
      real(Dp) :: iso_energy ! an iso energy for some properties at a fixed energy. replace iso_energy with iso_energy from version 2.7.2
@@ -631,10 +642,12 @@
 
      !> namelist parameters
      namelist /PARAMETERS/ E_arc, Fermi_broadening, EF_integral_range, OmegaNum, OmegaNum_unfold, OmegaMin, OmegaMax, &
-        Eta_Arc, iso_energy, Nk1, Nk2, Nk3, NP, Gap_threshold, Tmin, Tmax, NumT, &
+        Lindhard_omega_num, Lindhard_omega_min, Lindhard_omega_max, Lindhard_broadening, &
+        Eta_Arc, iso_energy, Nk1, Nk2, Nk3, Lindhard_Nk1, Lindhard_Nk2, Lindhard_Nk3, &
+        Lindhard_Nq1, Lindhard_Nq2, Lindhard_Nq3, Lindhard_q_start, Lindhard_output, NP, Gap_threshold, Tmin, Tmax, NumT, &
         NBTau, BTauNum, BTauMax, Rcut, Magp, Magq, Magp_min, Magp_max, Nslice_BTau_Max, &
-        wcc_neighbour_tol, wcc_calc_tol, Beta,NumLCZVecs, iprint_level, &
-        Relaxation_Time_Tau,  symprec, arpack_solver, RKF45_PERIODIC_LEVEL, &
+        wcc_neighbour_tol, wcc_calc_tol, Beta, NumLCZVecs, iprint_level, &
+        Relaxation_Time_Tau, symprec, arpack_solver, RKF45_PERIODIC_LEVEL, &
         NumRandomConfs, NumSelectedEigenVals, projection_weight_mode, topsurface_atom_index, &
         photon_energy_arpes, polarization_xi_arpes, test_namelist, nnzmax_input, &
         polarization_alpha_arpes, polarization_delta_arpes, penetration_lambda_arpes, polarization_phi_arpes, &
@@ -927,6 +940,7 @@
      real(dp) :: K3D_vec1_cube(3) ! the 1st k vector for the k cube
      real(dp) :: K3D_vec2_cube(3) ! the 2nd k vector for the k cube
      real(dp) :: K3D_vec3_cube(3) ! the 3rd k vector for the k cube
+     real(dp) :: Lindhard_q_start(3) ! starting q-vector for Lindhard calculation
 
      integer, allocatable     :: irvec(:,:)   ! R coordinates in fractional units
      integer, allocatable     :: irvec_valley(:,:)   ! R coordinates in fractional units

--- a/src/readinput.f90
+++ b/src/readinput.f90
@@ -129,6 +129,7 @@ subroutine readinput
    BerryCurvature_kpath_Occupied_calc = .FALSE.
    MirrorChern_calc      = .FALSE.
    Dos_calc              = .FALSE.
+   Lindhard_calc         = .FALSE.
    Dos_slab_calc              = .FALSE.
    JDos_calc             = .FALSE.
    EffectiveMass_calc    = .FALSE.
@@ -193,6 +194,7 @@ subroutine readinput
       write(*, *)"BerryCurvature_kpath_sepband_calc"
       write(*, *)"BerryCurvature_slab_calc, BerryCurvature_Cube_calc"
       write(*, *)"Dos_calc, JDos_calc, FindNodes_calc"
+      write(*, *)"Lindhard_calc"
       write(*, *)"BulkFS_plane_calc"
       write(*, *)"BulkFS_plane_stack_calc"
       write(*, *)"Z2_3D_calc"
@@ -275,6 +277,7 @@ subroutine readinput
       write(stdout, *) "BerryCurvature_Cube_calc          : ", BerryCurvature_Cube_calc
       write(stdout, *) "BerryCurvature_slab_calc          : ", BerryCurvature_slab_calc
       write(stdout, *) "Dos_calc                          : ",  DOS_calc
+      write(stdout, *) "Lindhard_calc                     : ",  Lindhard_calc
       write(stdout, *) "Z2_3D_calc                        : ",  Z2_3D_calc
       write(stdout, *) "WeylChirality_calc                : ",  WeylChirality_calc
       write(stdout, *) "NLChirality_calc                  : ",  NLChirality_calc
@@ -593,9 +596,21 @@ subroutine readinput
    OmegaNum_unfold = 0
    OmegaMin = -1d0
    OmegaMax =  1d0
+   Lindhard_omega_min = OmegaMin
+   Lindhard_omega_max = OmegaMax
+   Lindhard_omega_num = OmegaNum
+   Lindhard_broadening = Fermi_broadening
    Nk1 = 10
    Nk2 = 10
-   Nk3 = 1 
+   Nk3 = 1
+   Lindhard_Nk1 = Nk1
+   Lindhard_Nk2 = Nk2
+   Lindhard_Nk3 = Nk3
+   Lindhard_Nq1 = Nk1
+   Lindhard_Nq2 = Nk2
+   Lindhard_Nq3 = Nk3
+   Lindhard_q_start = (/0d0, 0d0, 0d0/)
+   Lindhard_output = 'lindhard.dat'
    NP  = 2
    Gap_threshold= 0.01d0
    Tmin = 100.  ! in Kelvin
@@ -650,6 +665,16 @@ subroutine readinput
       if (OmegaNum_unfold==0) OmegaNum_unfold= 200
    endif
 
+   if (Lindhard_Nk1<1) Lindhard_Nk1 = Nk1
+   if (Lindhard_Nk2<1) Lindhard_Nk2 = Nk2
+   if (Lindhard_Nk3<1) Lindhard_Nk3 = Nk3
+   if (Lindhard_Nq1<1) Lindhard_Nq1 = Lindhard_Nk1
+   if (Lindhard_Nq2<1) Lindhard_Nq2 = Lindhard_Nk2
+   if (Lindhard_Nq3<1) Lindhard_Nq3 = Lindhard_Nk3
+   if (Lindhard_omega_num<2) Lindhard_omega_num = max(2, OmegaNum)
+   if (Lindhard_broadening<=0d0) Lindhard_broadening = Fermi_broadening
+   if (len_trim(Lindhard_output)==0) Lindhard_output = 'lindhard.dat'
+
 
    if (stat>0) then
 
@@ -680,9 +705,21 @@ subroutine readinput
       write(stdout, '(1x, a, f16.5, a)')'OmegaMax : ', OmegaMax, ' eV'
       write(stdout, '(1x, a, i6   )')'OmegaNum : ', OmegaNum
       write(stdout, '(1x, a, i6   )')'OmegaNum_unfold : ', OmegaNum_unfold
+      write(stdout, '(1x, a, f16.5, a)')'Lindhard_omega_min : ', Lindhard_omega_min, ' eV'
+      write(stdout, '(1x, a, f16.5, a)')'Lindhard_omega_max : ', Lindhard_omega_max, ' eV'
+      write(stdout, '(1x, a, i6   )')'Lindhard_omega_num : ', Lindhard_omega_num
+      write(stdout, '(1x, a, f16.5, a)')'Lindhard_broadening : ', Lindhard_broadening, ' eV'
       write(stdout, '(1x, a, i6   )')'Nk1 : ', Nk1
       write(stdout, '(1x, a, i6   )')'Nk2 : ', Nk2
       write(stdout, '(1x, a, i6   )')'Nk3 : ', Nk3
+      write(stdout, '(1x, a, i6   )')'Lindhard_Nk1 : ', Lindhard_Nk1
+      write(stdout, '(1x, a, i6   )')'Lindhard_Nk2 : ', Lindhard_Nk2
+      write(stdout, '(1x, a, i6   )')'Lindhard_Nk3 : ', Lindhard_Nk3
+      write(stdout, '(1x, a, i6   )')'Lindhard_Nq1 : ', Lindhard_Nq1
+      write(stdout, '(1x, a, i6   )')'Lindhard_Nq2 : ', Lindhard_Nq2
+      write(stdout, '(1x, a, i6   )')'Lindhard_Nq3 : ', Lindhard_Nq3
+      write(stdout, '(1x, a, 3f16.5)')'Lindhard_q_start : ', Lindhard_q_start
+      write(stdout, '(1x, a, a    )')'Lindhard_output : ', trim(Lindhard_output)
       write(stdout, '(1x, a, i6   )')'NP number of principle layers  : ', Np
       write(stdout, '(1x, a, f16.5)')'Tmin(Kelvin)  : ', Tmin
       write(stdout, '(1x, a, f16.5)')'Tmax(Kelvin)  : ', Tmax
@@ -722,6 +759,9 @@ subroutine readinput
    Fermi_broadening = Fermi_broadening*eV2Hartree
    OmegaMin= OmegaMin*eV2Hartree
    OmegaMax= OmegaMax*eV2Hartree
+   Lindhard_omega_min = Lindhard_omega_min*eV2Hartree
+   Lindhard_omega_max = Lindhard_omega_max*eV2Hartree
+   Lindhard_broadening = Lindhard_broadening*eV2Hartree
    Gap_threshold= Gap_threshold*eV2Hartree
    Rcut= Rcut*Ang2Bohr
    penetration_lambda_arpes= penetration_lambda_arpes*Ang2Bohr


### PR DESCRIPTION
## Summary
- add the Lindhard control flag, defaults, and parameter handling so wt.in can request a susceptibility calculation
- implement the Lindhard Brillouin-zone loop and output routine and integrate it into the main workflow and build system
- document the new CONTROL option and Lindhard-specific PARAMETERS entries for users

## Testing
- `make -C src lindhard.o` *(fails: gfortran not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da94d3c1e8832b9fc4074353a5dbda